### PR TITLE
Rename tdd-helper.el to wordnut-test-helper.el

### DIFF
--- a/test/test_history.el
+++ b/test/test_history.el
@@ -4,7 +4,7 @@
 (push tdd-lib-dir load-path)
 (push (file-name-directory load-file-name) load-path)
 
-(require 'tdd-helper)
+(require 'wordnut-test-helper)
 (require 'wordnut-history)
 
 (ert-deftest history-clean()

--- a/test/test_wordnut.el
+++ b/test/test_wordnut.el
@@ -4,7 +4,7 @@
 (push tdd-lib-dir load-path)
 (push (file-name-directory load-file-name) load-path)
 
-(require 'tdd-helper)
+(require 'wordnut-test-helper)
 (require 'wordnut)
 
 (ert-deftest link-raw-empty-buf()

--- a/test/wordnut-test-helper.el
+++ b/test/wordnut-test-helper.el
@@ -20,4 +20,4 @@
 	   hash))
 
 
-(provide 'tdd-helper)
+(provide 'wordnut-test-helper)


### PR DESCRIPTION
This avoids a conflict with your other package ph.