### PR TITLE
improve window management

### DIFF
--- a/wordnut-u.el
+++ b/wordnut-u.el
@@ -14,13 +14,6 @@
   (delq nil
 	(mapcar (lambda (x) (and (funcall condp x) x)) lst)))
 
-(defun wordnut-u-switch-to-buffer (buf)
-  (unless (eq (current-buffer) buf)
-    (unless (cdr (window-list))
-      (split-window-vertically))
-    (other-window 1)
-    (switch-to-buffer buf)))
-
 (defun wordnut-u-fix-name (str)
   (let ((max 10))
     (if (> (length str) max)

--- a/wordnut.el
+++ b/wordnut.el
@@ -90,7 +90,7 @@ Turning on wordnut mode runs the normal hook `wordnut-mode-hook'.
 	(setq adaptive-wrap-extra-indent 3)
 	(adaptive-wrap-prefix-mode 1))))
 
-(define-key wordnut-mode-map (kbd "q") 'delete-window)
+(define-key wordnut-mode-map (kbd "q") 'quit-window)
 (define-key wordnut-mode-map (kbd "RET") 'wordnut-lookup-current-word)
 (define-key wordnut-mode-map (kbd "l") 'wordnut-history-backward)
 (define-key wordnut-mode-map (kbd "r") 'wordnut-history-forward)
@@ -201,7 +201,7 @@ rerun `wordnut--lookup' with the selected word."
 
       (progress-reporter-update progress-reporter 2)
       (progress-reporter-done progress-reporter)
-      (wordnut-u-switch-to-buffer buf))
+      (pop-to-buffer buf))
     ))
 
 (defun wordnut--moveto (item)


### PR DESCRIPTION
* Use pop-to-buffer to open new windows. This brings in a bunch of nice logic around where to open the new buffer and what to do when we quit it. It also brings in all the display-buffer logic allowing users to configure the behaviour of this command.
* Use quit-window to quit the buffer. This invokes the nice pop-to-buffer logic when closing the window.

fixes #5